### PR TITLE
Feature/configure worker sizes with slider

### DIFF
--- a/src/modules/api/fragments.js
+++ b/src/modules/api/fragments.js
@@ -125,7 +125,6 @@ export const deploymentConfig = gql`
   fragment deploymentConfig on DeploymentConfig {
     defaults
     limits
-    presets
     astroUnit {
       cpu
       memory

--- a/src/modules/deployments/DeploymentConfigure/CeleryConfig.js
+++ b/src/modules/deployments/DeploymentConfigure/CeleryConfig.js
@@ -1,56 +1,53 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import s from './styles.scss'
-import { NumberField, Select, FormSubSection } from 'instruments'
+// import s from './styles.scss'
+import { NumberField, FormSubSection } from 'instruments'
 import info from '../info'
 
+import Resource from './Resource'
+
 import {
-  workerSizeConvert,
-  workerSizeInfo,
+  // workerSizeConvert,
+  // workerSizeInfo,
   workerTerminationUnits,
   workerTerminationConvert,
 } from './helpers'
 
-import Selector from './Selector'
-
-const workerSizes = [
-  {
-    icon: 'alien_ship',
-    value: 'small',
-    text: 'Small',
-    className: s.sizeS,
-  },
-  {
-    icon: 'alien_ship',
-    value: 'medium',
-    text: 'Medium',
-    className: s.sizeM,
-  },
-  {
-    icon: 'alien_ship',
-    value: 'large',
-    text: 'Large',
-    className: s.sizeL,
-  },
-]
+// const workerSizes = [
+//   {
+//     icon: 'alien_ship',
+//     value: 'small',
+//     text: 'Small',
+//     className: s.sizeS,
+//   },
+//   {
+//     icon: 'alien_ship',
+//     value: 'medium',
+//     text: 'Medium',
+//     className: s.sizeM,
+//   },
+//   {
+//     icon: 'alien_ship',
+//     value: 'large',
+//     text: 'Large',
+//     className: s.sizeL,
+//   },
+// ]
 
 const CeleryConfig = ({
   form,
-  deploymentConfig: { defaults, limits, presets },
+  deploymentConfig: { defaults, limits, presets, astroUnit },
 }) => {
   return (
     <FormSubSection title="Celery Executor Config">
-      <Select
-        {...form.field('config.workers.resources')}
-        label="Worker Size"
-        className={s.selectors}
-        defaultValue={presets.workerSizes.small}
-        Component={Selector}
-        options={workerSizes}
-        info={workerSizeInfo(presets.workerSizes)}
-        convert={(size, out) =>
-          workerSizeConvert(size, out, presets.workerSizes)
-        }
+      <Resource
+        label="Workers"
+        field={form.field('config.workers.resources.limits')}
+        defaultValue={defaults.workers.resources.requests}
+        max={limits.workers.resources.limits}
+        info={presets.workerSizes}
+        required
+        astroUnit={astroUnit}
       />
       <NumberField
         label="Worker Count"

--- a/src/modules/deployments/DeploymentConfigure/CeleryConfig.js
+++ b/src/modules/deployments/DeploymentConfigure/CeleryConfig.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-// import s from './styles.scss'
 import { NumberField, FormSubSection } from 'instruments'
 import info from '../info'
 

--- a/src/modules/deployments/DeploymentConfigure/CeleryConfig.js
+++ b/src/modules/deployments/DeploymentConfigure/CeleryConfig.js
@@ -6,37 +6,11 @@ import info from '../info'
 
 import Resource from './Resource'
 
-import {
-  // workerSizeConvert,
-  // workerSizeInfo,
-  workerTerminationUnits,
-  workerTerminationConvert,
-} from './helpers'
-
-// const workerSizes = [
-//   {
-//     icon: 'alien_ship',
-//     value: 'small',
-//     text: 'Small',
-//     className: s.sizeS,
-//   },
-//   {
-//     icon: 'alien_ship',
-//     value: 'medium',
-//     text: 'Medium',
-//     className: s.sizeM,
-//   },
-//   {
-//     icon: 'alien_ship',
-//     value: 'large',
-//     text: 'Large',
-//     className: s.sizeL,
-//   },
-// ]
+import { workerTerminationUnits, workerTerminationConvert } from './helpers'
 
 const CeleryConfig = ({
   form,
-  deploymentConfig: { defaults, limits, presets, astroUnit },
+  deploymentConfig: { defaults, limits, astroUnit },
 }) => {
   return (
     <FormSubSection title="Celery Executor Config">
@@ -45,7 +19,7 @@ const CeleryConfig = ({
         field={form.field('config.workers.resources.limits')}
         defaultValue={defaults.workers.resources.requests}
         max={limits.workers.resources.limits}
-        info={presets.workerSizes}
+        info={info.workerSize}
         required
         astroUnit={astroUnit}
       />


### PR DESCRIPTION
This PR reverts orbit back to using sliders instead of preconfigured tshirt sizes