### PR TITLE
Don't show the Extra Resources section in Single Namespace deployments

### DIFF
--- a/src/modules/api/fragments.js
+++ b/src/modules/api/fragments.js
@@ -136,6 +136,7 @@ export const deploymentConfig = gql`
     maxExtraAu
     executors
     latestVersion
+    singleNamespace
   }
 `
 

--- a/src/modules/deployments/DeploymentConfigure/ResourcesForm.js
+++ b/src/modules/deployments/DeploymentConfigure/ResourcesForm.js
@@ -10,6 +10,30 @@ import Executor from './Executor'
 import Resource from './Resource'
 import Usage from './Usage'
 
+class ExtraResourcesForm extends React.Component {
+  render() {
+    const { form, deploymentConfig } = this.props
+    return (
+        <Resource
+          label="Extra Capacity"
+          field={form.field('properties.extra_au')}
+          defaultValue={0}
+          min={0}
+          max={deploymentConfig.maxExtraAu}
+          step={10}
+          info={info.astroUnit}
+          convertValue={null}
+          astroUnit={deploymentConfig.astroUnit}
+        />
+    )
+  }
+}
+
+ExtraResourcesForm.propTypes = {
+  form: PropTypes.object,
+  deploymentConfig: PropTypes.object,
+}
+
 class ResourcesForm extends React.Component {
   componentDidMount() {
     this.props.loaded('resources')
@@ -51,19 +75,10 @@ class ResourcesForm extends React.Component {
             astroUnit={deploymentConfig.astroUnit}
           />
         </FormSection>
-
         <FormSection id="resources" title="Resources">
-          <Resource
-            label="Extra Capacity"
-            field={form.field('properties.extra_au')}
-            defaultValue={0}
-            min={0}
-            max={deploymentConfig.maxExtraAu}
-            step={10}
-            info={info.astroUnit}
-            convertValue={null}
-            astroUnit={deploymentConfig.astroUnit}
-          />
+          {deploymentConfig.singleNamespace || (
+            <ExtraResourcesForm {...this.props} />
+          )}
           <Usage
             extra={form.field('properties.extra_au').value}
             config={form.field('config').value}


### PR DESCRIPTION
If we are deploying in to the same namespace we are already running in
then we can't enforce any limits or constraints, so don't display that
section of the form.

(This mode is often used by users who don't manage their own Kube
cluster, but are given a namespace to use by a central team, so lack
permissions to create new namespaces.)

I don't know if this PR will play well with Houston v1, or if that matters.

Part of astronomer/astronomer#215

**Multi NS:**

![screen shot 2019-01-25 at 11 49 47](https://user-images.githubusercontent.com/34150/51744993-749c5b80-2099-11e9-8ded-5db94c33cc43.png)

**Single NS:**

![screen shot 2019-01-25 at 11 26 57](https://user-images.githubusercontent.com/34150/51745013-84b43b00-2099-11e9-8417-baa8cbe45ae2.png)
