### PR TITLE
Better handling of unknown non-form errors

### DIFF
--- a/src/modules/alerts/Data/Update.js
+++ b/src/modules/alerts/Data/Update.js
@@ -1,7 +1,7 @@
 'use strict'
 import React from 'react'
 import api from 'modules/deployments/Data/api'
-import { Mutation } from 'instruments'
+import { Mutation, CardError } from 'instruments'
 
 const Update = Component => {
   const Update = props => {
@@ -11,7 +11,7 @@ const Update = Component => {
         success="Deployment alerts updated successfully."
         track="Deployment Alerts Updated"
         voidError>
-        {({ mutate }) => {
+        {({ mutate, error }) => {
           const newProps = {
             ...props,
             onSubmit: vars => {
@@ -35,6 +35,8 @@ const Update = Component => {
           // handle api errors
           // const err = handleError(error)
           // if (err) newProps.error = err
+          if (error) return <CardError />
+
           return <Component {...newProps} />
         }}
       </Mutation>

--- a/src/modules/auth/Data/Create.js
+++ b/src/modules/auth/Data/Create.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import api from './api'
 import { handleError } from './helpers'
 
-import { Create as Mutation, SetData } from 'instruments'
+import { Create as Mutation, SetData, CardError } from 'instruments'
 
 const Create = Component => {
   const Create = ({ login, vars, setData, to, ...props }) => {
@@ -70,6 +70,7 @@ const Create = Component => {
           // handle api errors
           const err = handleError(error)
           if (err) newProps.error = err
+          else if (error) return <CardError />
 
           return <Component {...newProps} />
         }}

--- a/src/modules/auth/Data/ForgotPw.js
+++ b/src/modules/auth/Data/ForgotPw.js
@@ -3,7 +3,7 @@ import React from 'react'
 import api from './api'
 import { handleError } from './helpers'
 
-import { Mutation } from 'instruments'
+import { Mutation, CardError } from 'instruments'
 
 const ForgotPw = Component => {
   const ForgotPw = props => {
@@ -26,6 +26,7 @@ const ForgotPw = Component => {
           // handle api errors
           const err = handleError(error)
           if (err) newProps.error = err
+          else if (error) return <CardError />
 
           return <Component {...newProps} />
         }}

--- a/src/modules/deployments/Data/Create.js
+++ b/src/modules/deployments/Data/Create.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 
 import api from './api'
 
-import { Create as Mutation, GetData } from 'instruments'
+import { Create as Mutation, GetData, CardError } from 'instruments'
 import { handleError } from './helpers'
 
 const Create = Component => {
@@ -40,6 +40,8 @@ const Create = Component => {
           // handle api errors
           const err = handleError(error)
           if (err) newProps.error = err
+          else if (error) return <CardError />
+
           return <Component {...newProps} />
         }}
       </Mutation>

--- a/src/modules/deployments/Data/Update.js
+++ b/src/modules/deployments/Data/Update.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import api from './api'
 
-import { Mutation } from 'instruments'
+import { Mutation, CardError } from 'instruments'
 import { handleError, trimError } from './helpers'
 const Update = Component => {
   const Update = props => {
@@ -35,6 +35,8 @@ const Update = Component => {
           // handle api errors
           const err = handleError(error)
           if (err) newProps.error = err
+          else if (error) return <CardError />
+
           return <Component {...newProps} />
         }}
       </Mutation>


### PR DESCRIPTION
We have (via `handleErrors`) handled errors against specific form
fields, but if there is an unrecognized error this lets many forms to
either report success, or to silently do nothing.

This updates all the forms using this pattern to instead display a
generic "DAG gone it" generic error in place of the component.

I would have preferrred a more "global" way of handling this once, but
I don't think given the current code layout that is possible.