### PR TITLE
Remove Airflow version tag from Deployment Config form

### DIFF
--- a/src/modules/deployments/DeploymentConfigure/Info.js
+++ b/src/modules/deployments/DeploymentConfigure/Info.js
@@ -29,14 +29,14 @@ const Info = ({ deployment }) => {
           </Tag>
         </React.Fragment>
       )}
-      <Tag>
+      {/* <Tag>
         <span>Airflow </span>
         <B>
           v{deployment && deployment.airflowVersion
             ? deployment.airflowVersion
             : '1.10.2'}
         </B>
-      </Tag>
+      </Tag> */}
     </div>
   )
 }


### PR DESCRIPTION
This PR removes the hard-coded Airflow version that currently shows as `Airflow 1.9`. As of now, we don't have an easy way of accessing the Airflow version of specific deployments, so we're going to remove this tag from the UI until we can ensure it renders the correct information.