### PR TITLE
Tweak GitHub auth button colour

### DIFF
--- a/src/instruments/links/OauthButton/styles.scss
+++ b/src/instruments/links/OauthButton/styles.scss
@@ -36,7 +36,7 @@
     }
   }
   &.github {
-    background: #53514e;
+    background: #383838;
     span {
       background: left/auto 2.1em no-repeat url('./img/github.svg');
     }


### PR DESCRIPTION
Change to slightly darker grey as requested by Chris.