### PR TITLE
Fix stream flip during 30 min window

### DIFF
--- a/src/modules/metrics/DeploymentMetrics/index.js
+++ b/src/modules/metrics/DeploymentMetrics/index.js
@@ -61,7 +61,7 @@ class DeploymentMetrics extends React.Component {
         step = 6720
         break
       default:
-        step = 10
+        step = 5
         break
     }
 


### PR DESCRIPTION
Attached to https://github.com/astronomer/astronomer/issues/376

I believe this corrects the issue - as I'm not able to replicate it after making these changes. Can I get more eyes/testing on this to ensure that what I'm seeing isn't a one-off instance @ryw?

Please r/m