### PR TITLE
Fix deployment config overwrite & AU reset

### DIFF
--- a/src/instruments/api/Query/index.js
+++ b/src/instruments/api/Query/index.js
@@ -25,7 +25,7 @@ const Query = ({
       variables={vars}
       skip={skip}
       errorPolicy="all">
-      {({ loading, error, data, subscribeToMore }) => {
+      {({ loading, error, data, subscribeToMore, refetch }) => {
         if (loading) return <Loading /> // return this instead of updating contextUI
         if (error) {
           if (OnError) return OnError
@@ -76,7 +76,8 @@ const Query = ({
             })
           })
         }
-        const newProps = { data: data3 || data2 }
+
+        const newProps = { data: data3 || data2, refetch }
 
         if (subscribe) {
           newProps.subscribeToMore = () => {
@@ -100,6 +101,7 @@ const Query = ({
             })
           }
         }
+
         return children(newProps) || null
       }}
     </Apollo>

--- a/src/instruments/forms/Form/index.js
+++ b/src/instruments/forms/Form/index.js
@@ -44,8 +44,12 @@ const Form = FormComponent => {
     }
 
     shouldComponentUpdate(nextProps, nextState) {
+      // Refetch the parent data and update the payload as needed
+      if (this.props.refetch) this.props.refetch()
+
       if (!jsonEqual(this.state, nextState)) return true
       if (!jsonEqual(this.props, nextProps)) return true
+
       return false
     }
 
@@ -223,6 +227,7 @@ const Form = FormComponent => {
     children: PropTypes.element,
     saveOnLoad: PropTypes.bool, // if true, will enable saving preloaded data
     alert: PropTypes.bool, // if true, will enable saving preloaded data
+    refetch: PropTypes.func,
   }
 
   Form.defaultProps = {

--- a/src/modules/deployments/Data/Config.js
+++ b/src/modules/deployments/Data/Config.js
@@ -12,10 +12,15 @@ const Data = Component => {
       workspaceId: getData.workspaceId,
     }
     return (
-      <Query gql={api.DeploymentConfig} vars={vars} skip={skip}>
-        {({ data: { deploymentConfig } }) => {
+      <Query
+        gql={api.DeploymentConfig}
+        vars={vars}
+        skip={skip}
+        fetchPolicy="network-only">
+        {({ data: { deploymentConfig }, refetch }) => {
           const newProps = {
             ...otherProps,
+            refetch,
             deploymentConfig,
           }
           return <Component {...newProps} />

--- a/src/modules/deployments/Data/Update.js
+++ b/src/modules/deployments/Data/Update.js
@@ -22,8 +22,6 @@ const Update = Component => {
               const { id, config, env } = vars
               let { ...payload } = vars
 
-              console.log(vars);
-
               const variables = {
                 id,
                 payload,
@@ -37,6 +35,7 @@ const Update = Component => {
               })
             },
           }
+
           // handle api errors
           const err = handleError(error)
           if (err) newProps.error = err

--- a/src/modules/deployments/Data/Update.js
+++ b/src/modules/deployments/Data/Update.js
@@ -1,7 +1,6 @@
 'use strict'
 import React from 'react'
 import api from './api'
-import { reduce, isEqual } from 'lodash'
 
 import { Mutation, CardError } from 'instruments'
 import { handleError, trimError } from './helpers'

--- a/src/modules/deployments/Data/Update.js
+++ b/src/modules/deployments/Data/Update.js
@@ -22,26 +22,7 @@ const Update = Component => {
               const { id, config, env } = vars
               let { ...payload } = vars
 
-              // Find and return diff between previous config and new config
-              const diff = reduce(
-                payload,
-                (result, value, key) => {
-                  return isEqual(value, props.deployment[key]) // eslint-disable-line
-                    ? result
-                    : result.concat({ [key]: value })
-                },
-                []
-              )
-
-              // Filter out reiterated payload values (not to be used in "payload")
-              const newPayload = diff.filter(d => {
-                for (let key in d) {
-                  if (key != 'id') return d
-                }
-              })
-
-              // Update the payload w/ only the values the user is changing
-              payload = newPayload[0]
+              console.log(vars);
 
               const variables = {
                 id,

--- a/src/modules/deployments/DeploymentConfigure/UpdateForm.js
+++ b/src/modules/deployments/DeploymentConfigure/UpdateForm.js
@@ -14,9 +14,11 @@ import { isTrialing } from 'helpers/trial'
 class Configure extends React.Component {
   mounted = true
   renderConfig = this.renderConfig.bind(this)
+
   state = {
     renderConfig: false,
   }
+
   // delay rendering of config for lazy loading (ux performance)
   componentWillMount() {
     this.mounted = setTimeout(
@@ -24,9 +26,11 @@ class Configure extends React.Component {
       10
     )
   }
+
   componentDidMount() {
     this.props.loaded('configure')
   }
+
   componentWillUnmount() {
     clearTimeout(this.mounted)
   }
@@ -39,6 +43,7 @@ class Configure extends React.Component {
   render() {
     const { form, deployment } = this.props
     const disabled = isTrialing(deployment.workspace)
+
     return (
       <CardForm
         title="Configure"
@@ -86,6 +91,7 @@ Configure.propTypes = {
   deployment: PropTypes.object,
   deploymentConfig: PropTypes.object,
   loaded: PropTypes.func,
+  refetch: PropTypes.func,
 }
 
 export default DeploymentConfig(Form(Configure))


### PR DESCRIPTION
Attached to https://github.com/astronomer/astronomer/issues/402 & https://github.com/astronomer/astronomer/issues/322

Removing the previous fix, this update resorts to refetching the `deploymentConfig` query when the form checks if it should update (when a field is being changed). This pushes new `deploymentConfig` data to the `deployment` prop of `UpdateForm`. Also changed the fetch policy of `deploymentConfig` to `network-only` so the 1st fetch will always be from the network at not a the cache. 

Beyond re-querying for the most recent `deploymentConfig` while changing form fields I'm not sure what else to do in order to assume the form payload is always current when submitted.

Another possible fix here would be to create a Houston subscription that listens to changes to the deployment object. We could then subscribe to that in Orbit and continuously update the deployment config form to reflect the new data. 

Thoughts?