### PR TITLE
Unsaved changes warning

### DIFF
--- a/src/instruments/forms/Form/index.js
+++ b/src/instruments/forms/Form/index.js
@@ -210,7 +210,6 @@ const Form = FormComponent => {
       return (
         <form onSubmit={this.onSubmit} className={s.form}>
           <FormComponent {...newProps} />
-          {alert && <UnsavedChangesAlert alert={save} />}
         </form>
       )
     }

--- a/src/modules/deployments/Data/Update.js
+++ b/src/modules/deployments/Data/Update.js
@@ -12,8 +12,7 @@ const Update = Component => {
         success="Deployment updated successfully."
         track="Deployment Updated"
         voidError
-        errorMsg={trimError}
-        back>
+        errorMsg={trimError}>
         {({ mutate, error }) => {
           const newProps = {
             ...props,


### PR DESCRIPTION
Attached to https://github.com/astronomer/astronomer/issues/414

Since we have corrected the issue with data being overwritten as well as the render issue with the services selector we no longer need to redirect back when updating a deployment config. 

This corrects the "unsaved" changes issue as well as provides the intended UX (it's jarring to redirect back after saving 1 config set).

Please r/m 