### PR TITLE
Add a circleCI image pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     executor: docker-executor
     steps:
       - push:
-          comma_separated_tags: "dev,edge,$CIRCLE_SHA1"
+          comma_separated_tags: "dev,$CIRCLE_SHA1"
           image_name: ap-orbit-ui
   publish-prod:
     executor: docker-executor
@@ -23,27 +23,45 @@ jobs:
       - push:
           comma_separated_tags: "master,latest"
           image_name: ap-orbit-ui
-  publish-release:
+  # This is a special case. Only when a branch matches
+  # release-* do we also publish the image with a tag
+  # matching the name of the branch.
+  publish-release-branch:
     executor: docker-executor
     steps:
       - push:
           comma_separated_tags: "$CIRCLE_BRANCH"
           image_name: ap-orbit-ui
-  publish-version:
+  # This step requires manual approval - see the workflow. The result
+  # is a PR to the Helm chart with the new image and Chart.yaml versions
+  # incremented in the umbrella and sub charts. If this process occurs
+  # more than once before a new Helm release, then the existing Docker
+  # tag and GitHub release for this repository are replaced to include
+  # the additional changes.
+  github-release:
     executor: docker-executor
     steps:
-      - alias-tag:
-          from_tag: "$CIRCLE_SHA1"
-          alias: "$CIRCLE_TAG"
+      - checkout
+      # Set $NEXT_HELM_TAG to the most recent Helm chart GitHub release base version
+      # ('base' meaning 0.10.0-alpha.1 is translated to 0.10.0) with the patch version
+      # incremented by one. Does not include "v" in front. For example, if the most
+      # recent release referres to tag "v0.10.0-alpha.1", then the environment variable
+      # is set to 0.10.1
+      - get-next-helm-tag
+      # Push a Docker image tagged as the next helm tag.
+      - push:
+          comma_separated_tags: "$NEXT_HELM_TAG"
           image_name: ap-orbit-ui
-  pr-to-helm-chart:
-    executor: docker-executor
-    steps:
+      # Publish a GitHub release on this repository,
+      # automatically generating a change log.
+      - publish-github-release:
+          tag: "$NEXT_HELM_TAG"
+      # Open a PR to the helm chart with this new version.
       - pr-to-helm-chart:
           repository: "helm.astronomer.io"
           file: "charts/astronomer/values.yaml"
           yaml_key: "images.orbit.tag"
-          new_version: "$CIRCLE_TAG"
+          new_version: "$NEXT_HELM_TAG"
           reversion_chart_files: "Chart.yaml,charts/astronomer/Chart.yaml"
 workflows:
   version: 2.1
@@ -62,34 +80,42 @@ workflows:
           filters:
             branches:
               only: master
-      - publish-release:
+      # This step is just for a special case of
+      # branch naming.
+      - publish-release-branch:
           requires:
             - scan
           filters:
             branches:
               only: '/release-.*/'
-  publish-version:
-    jobs:
-      - publish-version:
-          filters:
-            tags:
-              only: '/v[0-9].*/'
-            branches:
-              ignore: '/.*/'
-      - pr-to-helm-chart:
+      # 'release-approval' requires that an in-app button be clicked
+      # by an authorized member of the project to continue.
+      # Then a versioned image will be published as one more than
+      # current helm chart version, a Github release will be made
+      # with automatically generated release notes, and a PR
+      # will be opened to the Helm chart repository including the
+      # new version.
+      - release-approval:
+          type: approval
           requires:
-            - publish-version
+           - publish-prod
+           - publish-dev
           filters:
-            tags:
-              only: '/v[0-9].*/'
             branches:
-              ignore: '/.*/'
+              only: master
+      - github-release:
+          requires:
+            - release-approval
+          filters:
+            branches:
+              only: master
 orbs:
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
   docker-executor:
     environment:
       GIT_ORG: sjmiller609
+      DOCKER_REPO: sjmiller609
     docker:
       - image: circleci/python:3
 commands:
@@ -140,9 +166,9 @@ commands:
       comma_separated_tags:
         type: string
         default: latest
-      organization:
+      docker_repository:
         type: string
-        default: $GIT_ORG
+        default: $DOCKER_REPO
       image_name:
         type: string
         default: $CIRCLE_PROJECT_REPONAME
@@ -168,46 +194,102 @@ commands:
               if [[ $tag =~ $pattern ]]; then
                 tag="${tag:1}"
               fi
-              docker tag << parameters.image_name >> << parameters.organization >>/<< parameters.image_name >>:${tag}
-              docker push << parameters.organization >>/<< parameters.image_name >>:${tag}
+              docker tag << parameters.image_name >> << parameters.docker_repository >>/<< parameters.image_name >>:${tag}
+              docker push << parameters.docker_repository >>/<< parameters.image_name >>:${tag}
               set +x
             done
-  alias-tag:
-    description: "Add tags for an image on Dockerhub"
+  publish-github-release:
+    description: "Create a release on GitHub"
     parameters:
-      from_tag:
+      tag:
         type: string
-        default: "$CIRCLE_SHA1"
-      alias:
+        default:  "$NEXT_HELM_TAG"
+      ghr_version:
         type: string
-        default: "0.0.0"
+        default:  "0.13.0"
+    steps:
+      - run:
+          name: Tag the current branch, forcing if the same tag exists on a previous commit
+          command: |
+            set -xe
+
+            # Install ghr, a CLI tool for doing GitHub releases
+            WORK_DIR=$(pwd)
+            cd /tmp
+            wget https://github.com/tcnksm/ghr/releases/download/v<< parameters.ghr_version >>/ghr_v<< parameters.ghr_version >>_linux_amd64.tar.gz
+            tar -xvfz ./ghr_v<< parameters.ghr_version >>_linux_amd64.tar.gz
+            mkdir -p /tmp/bin
+            mv ghr_v<< parameters.ghr_version >>_linux_amd64/ghr /tmp/bin/
+            export PATH=/tmp/bin:$PATH
+            cd $WORK_DIR
+
+            # Delete the tag from the local repository, if it exists.
+            # This is done so the release notes are generated
+            # correctly in the event of an overwrite.
+            git tag -d << parameters.tag >> || true
+
+            # Generate release notes in Markdown format
+            COMMITS=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"* %ai %h: %s" | awk '{$4=""; print $0}')
+            AUTHORS=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"%aE" | awk '!a[$0]++')
+            cat \<<EOT > release_notes.md
+            ## Changes:
+
+            $COMMITS
+
+            ## Authors:
+
+            $AUTHORS
+            EOT
+            echo "==================="
+            cat release_notes.md
+            echo "==================="
+
+            # Existing, matching release and tag will be overwritten, if present
+            ghr \
+              -t $GITHUB_TOKEN \
+              -c $CIRCLE_SHA1 \
+              -n v<< parameters.tag>> \
+              -b $(cat release_notes.md) \
+              -delete \
+              -replace \
+              v<< parameters.tag>>
+  get-next-helm-tag:
+    description: "Set an environment variable to the current Helm chart version with the patch number incremented by one"
+    parameters:
       organization:
         type: string
         default: $GIT_ORG
+      repository:
+        type: string
+        default: helm.astronomer.io
       image_name:
         type: string
         default: $CIRCLE_PROJECT_REPONAME
     steps:
-      - setup_remote_docker
       - run:
-          name: Login to DockerHub
-          command: echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
-      - run:
-          name: Download Docker image from Dockerhub
+          name: Determine the next Helm chart version
           command: |
-            docker pull << parameters.organization >>/<< parameters.image_name >>:<< parameters.from_tag >>
-      - run:
-          name: Tag image and push
-          command: |
-            set -xe
-            # If the tag looks starts with "v" then a digit, remove the "v"
-            tag="<< parameters.alias >>"
-            pattern="^(v[0-9].*)"
-            if [[ $tag =~ $pattern ]]; then
-              tag="${tag:1}"
-            fi
-            docker tag << parameters.organization >>/<< parameters.image_name >>:<< parameters.from_tag >> << parameters.organization >>/<< parameters.image_name >>:${tag}
-            docker push << parameters.organization >>/<< parameters.image_name >>:${tag}
+            set -e
+            pip install --user requests
+            cat > /tmp/next_helm_version.py \<<- EOM
+            import sys
+            import json
+            import requests
+            from packaging.version import parse as semver
+            most_recent_tag= json.loads(requests.get("https://api.github.com/repos/<< parameters.organization >>/<< parameters.repository >>/releases").text)[0]['tag_name']
+            print(f"Most recent helm release tag: {most_recent_tag}", file=sys.stderr)
+            base_version = semver(most_recent_tag).base_version
+            print(f"Parsed base version as {base_version}", file=sys.stderr)
+            base_version = semver(base_version)
+            major, minor, patch = base_version.release
+            patch += 1
+            new_version = ".".join(str(i) for i in [major, minor, patch])
+            print(f"Calculated new version as {new_version}", file=sys.stderr)
+            sys.stdout.write(new_version)
+            EOM
+            NEXT_HELM_TAG=$(python /tmp/next_helm_version)
+            # Make this environment variable available to following steps
+            echo "export NEXT_HELM_TAG=${NEXT_HELM_TAG}" >> $BASH_ENV
   pr-to-helm-chart:
     description: "Make a PR to another repository, modifying one YAML file"
     parameters:
@@ -225,6 +307,9 @@ commands:
       reversion_chart_files:
         type: string
         default: "Chart.yaml"
+      git_org:
+        type: string
+        default: $GIT_ORG
     steps:
       - run:
           name: Clone repository
@@ -233,7 +318,7 @@ commands:
             mkdir -p $HOME/.ssh || true
             ssh-keyscan -t rsa github.com >> $HOME/.ssh/known_hosts
             cd /tmp
-            git clone git@github.com:${GIT_ORG}/<< parameters.repository >>.git
+            git clone git@github.com:<< parameters.git_org >>/<< parameters.repository >>.git
       - run:
           name: Checkout a new branch
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,124 @@
+version: 2.1
+jobs:
+  build:
+    executor: docker-executor
+    steps:
+      - docker-build:
+          image_name: ap-orbit-ui
+          dockerfile: Dockerfile.prod
+  scan:
+    executor: clair-scanner/default
+    steps:
+      - clair-scan:
+          image_name: ap-orbit-ui
+  publish-dev:
+    executor: docker-executor
+    steps:
+      - push:
+          comma_separated_tags: "dev,edge,$CIRCLE_SHA1"
+          image_name: ap-orbit-ui
+  publish-prod:
+    executor: docker-executor
+    steps:
+      - push:
+          comma_separated_tags: "master,latest"
+          image_name: ap-orbit-ui
+workflows:
+  version: 2.1
+  build-images:
+    jobs:
+      - build
+      - scan:
+          requires:
+            - build
+      - publish-dev:
+          requires:
+            - scan
+      - publish-prod:
+          requires:
+            - scan
+          filters:
+            branches:
+              only: master
+orbs:
+  clair-scanner: ovotech/clair-scanner@1.6.0
+executors:
+  docker-executor:
+    environment:
+      GIT_ORG: astronomerinc
+    docker:
+      - image: circleci/buildpack-deps:stretch
+commands:
+  docker-build:
+    description: "Build a Docker image"
+    parameters:
+      dockerfile:
+        type: string
+        default: Dockerfile
+      path:
+        type: string
+        default: "."
+      image_name:
+        type: string
+        default: $CIRCLE_PROJECT_REPONAME
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build the Docker image
+          command: |
+            set -xe
+            image_name="<< parameters.image_name >>"
+            docker build -t $image_name --file << parameters.path>>/<< parameters.dockerfile >> --build-arg BUILD_NUMBER=${CIRCLE_BUILD_NUM} << parameters.path >>
+            docker save -o << parameters.image_name >>.tar $image_name
+      - persist_to_workspace:
+          root: .
+          paths:
+            - './*.tar'
+  clair-scan:
+    description: "Vulnerability scan a Docker image"
+    parameters:
+      image_name:
+        type: string
+        default: $CIRCLE_PROJECT_REPONAME
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Move tarball to directory for scan
+          command: mkdir /tmp/tarballs && mv /tmp/workspace/<< parameters.image_name >>.tar /tmp/tarballs/
+      - clair-scanner/scan:
+          docker_tar_dir: /tmp/tarballs
+  push:
+    description: "Push a Docker image to DockerHub"
+    parameters:
+      comma_separated_tags:
+        type: string
+        default: latest
+      organization:
+        type: string
+        default: $GIT_ORG
+      image_name:
+        type: string
+        default: $CIRCLE_PROJECT_REPONAME
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/<< parameters.image_name >>.tar
+      - run:
+          name: Login to DockerHub
+          command: echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
+      - run:
+          name: Push Docker image(s)
+          command: |
+            set -e
+            for tag in $(echo "<< parameters.comma_separated_tags >>" | sed "s/,/ /g");
+            do
+              set -x
+              docker tag << parameters.image_name >> << parameters.organization >>/<< parameters.image_name >>:${tag}
+              docker push << parameters.organization >>/<< parameters.image_name >>:${tag}
+              set +x
+            done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,27 +67,27 @@ workflows:
   version: 2.1
   build-images:
     jobs:
-      - build
-      - scan:
-          requires:
-            - build
-      - publish-dev:
-          requires:
-            - scan
-      - publish-prod:
-          requires:
-            - scan
-          filters:
-            branches:
-              only: master
-      # This step is just for a special case of
-      # branch naming.
-      - publish-release-branch:
-          requires:
-            - scan
-          filters:
-            branches:
-              only: '/release-.*/'
+      # - build
+      # - scan:
+      #     requires:
+      #       - build
+      # - publish-dev:
+      #     requires:
+      #       - scan
+      # - publish-prod:
+      #     requires:
+      #       - scan
+      #     filters:
+      #       branches:
+      #         only: master
+      # # This step is just for a special case of
+      # # branch naming.
+      # - publish-release-branch:
+      #     requires:
+      #       - scan
+      #     filters:
+      #       branches:
+      #         only: '/release-.*/'
       # 'release-approval' requires that an in-app button be clicked
       # by an authorized member of the project to continue.
       # Then a versioned image will be published as one more than
@@ -97,9 +97,9 @@ workflows:
       # new version.
       - release-approval:
           type: approval
-          requires:
-           - publish-prod
-           - publish-dev
+          # requires:
+          #  - publish-prod
+          #  - publish-dev
           filters:
             branches:
               only: master
@@ -287,7 +287,7 @@ commands:
             print(f"Calculated new version as {new_version}", file=sys.stderr)
             sys.stdout.write(new_version)
             EOM
-            NEXT_HELM_TAG=$(python /tmp/next_helm_version)
+            NEXT_HELM_TAG=$(python /tmp/next_helm_version.py)
             # Make this environment variable available to following steps
             echo "export NEXT_HELM_TAG=${NEXT_HELM_TAG}" >> $BASH_ENV
   pr-to-helm-chart:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,28 @@ jobs:
       - push:
           comma_separated_tags: "master,latest"
           image_name: ap-orbit-ui
+  publish-release:
+    executor: docker-executor
+    steps:
+      - push:
+          comma_separated_tags: "$CIRCLE_BRANCH"
+          image_name: ap-orbit-ui
+  publish-version:
+    executor: docker-executor
+    steps:
+      - alias-tag:
+          from_tag: "$CIRCLE_SHA1"
+          alias: "$CIRCLE_TAG"
+          image_name: ap-orbit-ui
+  pr-to-helm-chart:
+    executor: docker-executor
+    steps:
+      - pr-to-helm-chart:
+          repository: "helm.astronomer.io"
+          file: "charts/astronomer/values.yaml"
+          yaml_key: "images.orbit.tag"
+          new_version: "$CIRCLE_TAG"
+          reversion_chart_files: "Chart.yaml,charts/astronomer/Chart.yaml"
 workflows:
   version: 2.1
   build-images:
@@ -40,14 +62,36 @@ workflows:
           filters:
             branches:
               only: master
+      - publish-release:
+          requires:
+            - scan
+          filters:
+            branches:
+              only: '/release-.*/'
+  publish-version:
+    jobs:
+      - publish-version:
+          filters:
+            tags:
+              only: '/v[0-9].*/'
+            branches:
+              ignore: '/.*/'
+      - pr-to-helm-chart:
+          requires:
+            - publish-version
+          filters:
+            tags:
+              only: '/v[0-9].*/'
+            branches:
+              ignore: '/.*/'
 orbs:
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
   docker-executor:
     environment:
-      GIT_ORG: astronomerinc
+      GIT_ORG: sjmiller609
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: circleci/python:3
 commands:
   docker-build:
     description: "Build a Docker image"
@@ -63,7 +107,8 @@ commands:
         default: $CIRCLE_PROJECT_REPONAME
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Build the Docker image
           command: |
@@ -118,7 +163,159 @@ commands:
             for tag in $(echo "<< parameters.comma_separated_tags >>" | sed "s/,/ /g");
             do
               set -x
+              # If the tag looks starts with "v" then a digit, remove the "v"
+              pattern="^(v[0-9].*)"
+              if [[ $tag =~ $pattern ]]; then
+                tag="${tag:1}"
+              fi
               docker tag << parameters.image_name >> << parameters.organization >>/<< parameters.image_name >>:${tag}
               docker push << parameters.organization >>/<< parameters.image_name >>:${tag}
               set +x
             done
+  alias-tag:
+    description: "Add tags for an image on Dockerhub"
+    parameters:
+      from_tag:
+        type: string
+        default: "$CIRCLE_SHA1"
+      alias:
+        type: string
+        default: "0.0.0"
+      organization:
+        type: string
+        default: $GIT_ORG
+      image_name:
+        type: string
+        default: $CIRCLE_PROJECT_REPONAME
+    steps:
+      - setup_remote_docker
+      - run:
+          name: Login to DockerHub
+          command: echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
+      - run:
+          name: Download Docker image from Dockerhub
+          command: |
+            docker pull << parameters.organization >>/<< parameters.image_name >>:<< parameters.from_tag >>
+      - run:
+          name: Tag image and push
+          command: |
+            set -xe
+            # If the tag looks starts with "v" then a digit, remove the "v"
+            tag="<< parameters.alias >>"
+            pattern="^(v[0-9].*)"
+            if [[ $tag =~ $pattern ]]; then
+              tag="${tag:1}"
+            fi
+            docker tag << parameters.organization >>/<< parameters.image_name >>:<< parameters.from_tag >> << parameters.organization >>/<< parameters.image_name >>:${tag}
+            docker push << parameters.organization >>/<< parameters.image_name >>:${tag}
+  pr-to-helm-chart:
+    description: "Make a PR to another repository, modifying one YAML file"
+    parameters:
+      repository:
+        type: string
+        default: "helm.astronomer.io"
+      file:
+        type: string
+        default: "charts/astronomer/values.yaml"
+      yaml_key:
+        type: string
+      new_version:
+        type: string
+        default: $CIRCLE_TAG
+      reversion_chart_files:
+        type: string
+        default: "Chart.yaml"
+    steps:
+      - run:
+          name: Clone repository
+          command: |
+            set -xe
+            mkdir -p $HOME/.ssh || true
+            ssh-keyscan -t rsa github.com >> $HOME/.ssh/known_hosts
+            cd /tmp
+            git clone git@github.com:${GIT_ORG}/<< parameters.repository >>.git
+      - run:
+          name: Checkout a new branch
+          command: |
+            set -xe
+            cd /tmp/<< parameters.repository >>
+            git checkout -b "automated-pr/${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}"
+            git branch
+      - run:
+          name: Modify Helm chart
+          command: |
+            set -xe
+            cd /tmp/<< parameters.repository >>
+
+            # If the value starts with "v" then a digit, remove the "v"
+            #
+            value="<< parameters.new_version >>"
+            pattern="^(v[0-9].*)"
+            if [[ $value =~ $pattern ]]; then
+              value="${value:1}"
+            fi
+
+            # Set up a python script to find and replace in YAML,
+            # including preservation of comments, key order, and so forth
+            #
+            pip install --user ruamel.yaml
+            cat > /tmp/modify.py \<<- EOM
+            import sys
+            from ruamel.yaml import YAML
+            from functools import reduce
+            import operator
+
+            with open("<< parameters.file >>", "r") as f:
+                file_content = f.read()
+
+            def getFromDict(dataDict, mapList):
+                return reduce(operator.getitem, mapList, dataDict)
+
+            def setInDict(dataDict, mapList, value):
+                getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value
+
+            yaml = YAML()
+            code = yaml.load(file_content)
+            path = "<< parameters.yaml_key >>".split(".")
+            setInDict(code, path, "<< parameters.new_version >>")
+
+            with open("<< parameters.file >>", "w") as f:
+              yaml.dump(code, f)
+
+            chart_files = "<< parameters.reversion_chart_files >>".split(",")
+            for file in chart_files:
+              with open(file, "r") as f:
+                file_content = f.read()
+              code = yaml.load(file_content)
+              code['version'] = "<< parameters.new_version >>"
+              with open(file, "w") as f:
+                yaml.dump(code, f)
+            EOM
+
+            # re-write the helm chart
+            python /tmp/modify.py
+
+            # add and commit
+            git add << parameters.file >>
+            git diff HEAD
+            git status
+
+            set +x
+            git config --global user.email "steven@astronomer.io"
+            git config --global user.name "Circle CI"
+            git config --global user.token $GITHUB_TOKEN
+            set -x
+
+            git commit -m "Circle CI: Update image to ${value}" -- << parameters.file >>
+      - run:
+          name: Open PR to helm repo
+          command: |
+            set -xe
+            cd /tmp/<< parameters.repository >>
+            # Install a tool that will let us open PRs from the command line
+            sudo apt-get install -y hub
+
+            # Open pull request
+            # GITHUB_TOKEN should be a present environment variable
+            # -p : push before make PR
+            hub pull-request -p -m "Circle CI: Update image to ${value}"

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,58 @@
+#
+# Copyright 2018 Astronomer Inc.
+#
+# Licensed under the Apache License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM astronomerinc/ap-base:0.10.3-alpha.3
+LABEL maintainer="Astronomer <humans@astronomer.io>"
+
+ARG BUILD_NUMBER=-1
+LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
+LABEL io.astronomer.docker.module="astronomer"
+LABEL io.astronomer.docker.component="orbit-ui"
+
+ENV ORBIT_PATH=/tmp/orbit-ui
+ENV SERVER_ROOT=/usr/share/nginx/html
+
+WORKDIR ${ORBIT_PATH}
+COPY . .
+
+RUN apk add --no-cache --virtual .build-deps \
+		build-base \
+		git \
+	&& apk add --no-cache \
+		gettext \
+		nginx \
+		nodejs \
+		nodejs-npm \
+		openssl \
+	&& npm install \
+	&& npm run build-production \
+	&& mkdir -p ${SERVER_ROOT} \
+	&& mv dist/* ${SERVER_ROOT} \
+	&& mv src/favicon.ico ${SERVER_ROOT} \
+	&& rm -rf ${ORBIT_PATH} \
+	&& mkdir -p /run/nginx \
+	&& apk del .build-deps
+
+# Copy entrypoint to root
+COPY include/entrypoint /
+
+# Copy NGINX configuration to default location
+COPY include/nginx.conf /etc/nginx/nginx.conf.tpl
+
+# NGINX is configured to listen on 8080
+EXPOSE 8080
+
+# Run NGINX
+ENTRYPOINT ["/entrypoint"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM astronomerinc/ap-base:latest
+FROM astronomerinc/ap-base:0.10.3
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -17,7 +17,6 @@ FROM astronomerinc/ap-base:0.10.3
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
-LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 LABEL io.astronomer.docker.module="astronomer"
 LABEL io.astronomer.docker.component="orbit-ui"
 
@@ -53,6 +52,8 @@ COPY include/nginx.conf /etc/nginx/nginx.conf.tpl
 
 # NGINX is configured to listen on 8080
 EXPOSE 8080
+
+LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 
 # Run NGINX
 ENTRYPOINT ["/entrypoint"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM astronomerinc/ap-base:0.10.3-alpha.3
+FROM astronomerinc/ap-base:latest
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1

--- a/include/entrypoint
+++ b/include/entrypoint
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+set -e
+
+# Substitue env vars
+envsubst '$APP_API_LOC_HTTPS $APP_API_LOC_WSS $ANALYTICS_TRACKING_ID $STRIPE_PK' < /etc/nginx/nginx.conf.tpl > /etc/nginx/nginx.conf
+
+# Run the original command
+exec nginx -g 'daemon off;'

--- a/include/nginx.conf
+++ b/include/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    include mime.types;
+    sendfile on;
+    server {
+        server_name localhost;
+        listen 8080;
+
+        location / {
+            root   /usr/share/nginx/html;
+            try_files $uri $uri/ /index.html;
+            sub_filter 'APP_API_LOC_HTTPS' '${APP_API_LOC_HTTPS}';
+            sub_filter 'APP_API_LOC_WSS' '${APP_API_LOC_WSS}';
+            sub_filter 'ANALYTICS_TRACKING_ID' '${ANALYTICS_TRACKING_ID}';
+            sub_filter 'STRIPE_PK' '${STRIPE_PK}';
+            sub_filter_once on;
+            add_header Cache-Control "no-store, no-cache, must-revalidate";
+        }
+
+        location ~* \.(css|ico|js|svg|woff|woff2)$ {
+            root   /usr/share/nginx/html;
+        }
+
+        location /healthz {
+            return 200;
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/astronomer/issues/issues/539

This PR is a part of the epic to speed up the release cadence to cloud. The first step is for each component in the platform to publish its own docker images. https://github.com/astronomer/issues/issues/465

The expectation is that @samblackk is working in a different branch than master, and PR to master is merged only after both CI passes. A push to any branch with publish a production-like image with tags edge, dev, and git commit hash. On a merge to master, this pipeline will build and publish the production docker image as master and latest (in addition to the other tags).

after we get all components of the platform publishing their own production-version of docker images, then we will have each component automatically publish to the helm chart, and the helm chart to test and release itself to stage cloud.

This pipeline requires the following to work @schnie 

- [ ] Circle CI: Turn on for this repo
- [ ] Circle CI: Opt-in to third party orbs
- [ ] Circle CI: Add DOCKER_USERNAME DOCKER_PASSWORD to circle CI environment variables

sample pipeline
![image](https://user-images.githubusercontent.com/7516283/68903464-3f84f680-0709-11ea-9d21-1bd608840152.png)


